### PR TITLE
Quake autotracking and Graveyard ledge+maiamai fixes

### DIFF
--- a/locations/hyrule.json
+++ b/locations/hyrule.json
@@ -302,7 +302,8 @@
                 "name": "Cave",
                 //"capture_item": true,
                 "access_rules": [
-                  "merge, not_cracksanity, quake",
+                  "[lampless], merge, not_cracksanity, quake, bombs, $lampless_access_lorule_graveyard",
+                  "merge, not_cracksanity, quake, bombs, $access_lorule_graveyard",
                   "merge, quake, crack_graveyard_lorule"
                 ],
                 "item_count": 1

--- a/locations/maiamai.json
+++ b/locations/maiamai.json
@@ -498,7 +498,8 @@
             "access_rules": [
               //"{}",
               "merge, crack_graveyard",
-              "not_cracksanity, merge, quake, crack_graveyard_lorule"
+              "not_cracksanity, merge, quake, bombs, $access_lorule_graveyard",
+              "[lampless], not_cracksanity, merge, quake, bombs, $lampless_access_lorule_graveyard"
             ],
             "visibility_rules": [
               "maiamai_map"

--- a/scripts/autotracking/item_mapping.lua
+++ b/scripts/autotracking/item_mapping.lua
@@ -27,7 +27,6 @@ ITEM_MAPPING = {
     [BASE + 23] = {"great_spin", "toggle"},
     [BASE + 24] = {"quake", "toggle"},
     [BASE + 31] = {"maiamai", "consumable"},
-    [BASE + 32] = {"quake", "toggle"},
     [BASE + 37] = {"bottle", "toggle"},
     [BASE + 38] = {"p_lamp", "progressive"},
     [BASE + 39] = {"p_sword", "progressive"},


### PR DESCRIPTION
- Fix Quake autotracking when receiving Monster Guts
- Fix Graveyard ledge and Maiamai logic to require bombs and [lamp or lampless setting]